### PR TITLE
Fix the acceptance test slowdown

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -20,7 +20,7 @@ const { set, reset } = MockDate || {
  * https://github.com/BackburnerJS/backburner.js/pull/264
  */
 const freezeDateAt = (...args) => {
-  trySet(Ember, 'run.backburner._platform.now', () => originalDate());
+  trySet(Ember, 'run.backburner._platform.now', originalDate.now);
   set(args);
 };
 


### PR DESCRIPTION
Fix for this issue: https://github.com/Ticketfly/ember-mockdate-shim/issues/3

The original now function in backburner calls the now function on the Date object itself, whereas this library currently invokes the Date object instead, returning a Date instance that is more costly - especially when called frequently.